### PR TITLE
Make general Authenticator to support using as decorator

### DIFF
--- a/aiohttp_oauth/__init__.py
+++ b/aiohttp_oauth/__init__.py
@@ -158,7 +158,7 @@ def _get_auth_handler(*, url, **kwargs):
             approved_domains=kwargs['google_approved_domains'])
     if 'gsuite_id' in kwargs:
         from . import gsuite
-        return gsuite.GSuiteOAuth(id_=kwargs['gsuite_id'],
+        return gsuite.GSuiteOAuth(id=kwargs['gsuite_id'],
                                   secret=kwargs['gsuite_secret'],
                                   redirect_uri=kwargs['gsuite_redirect_uri'],
                                   google_org=kwargs[


### PR DESCRIPTION
This refactors the middleware generation into a general Authenticator class
that can be used to define a decorator for views.

It does not define the decorator itself at this point, but the class can be used as one.